### PR TITLE
[Feature] iOS simulator auto-selection for seamless development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,12 @@ gh pr create \
   --assignee "@me"
 ```
 
+#### 커밋 및 PR 작성 시 주의사항
+- **절대 추가하지 말 것**: "🤖 Generated with [Claude Code](https://claude.ai/code)" 문구
+- **절대 추가하지 말 것**: "Co-Authored-By: Claude <noreply@anthropic.com>" 문구
+- 커밋 메시지와 PR 본문은 깔끔하고 간결하게 작성
+- 작업 내용만 명확히 설명하고 불필요한 메타 정보는 포함하지 않음
+
 ### 2.4 PR 머지 정책
 - 모든 PR은 반드시 squash 머지로 진행
 - 머지 후 로컬/원격 브랜치 자동 삭제
@@ -141,3 +147,9 @@ gh pr merge [PR번호] --squash --delete-branch
 - 정기적으로 룰의 예시와 실제 코드베이스 비교
 - 더 이상 사용되지 않는 패턴이나 구조 식별
 - 새롭게 도입된 패턴이나 구조가 룰에 반영되었는지 확인
+
+# important-instruction-reminders
+Do what has been asked; nothing more, nothing less.
+NEVER create files unless they're absolutely necessary for achieving your goal.
+ALWAYS prefer editing an existing file to creating a new one.
+NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.

--- a/frontend/scripts/setup-live-reload.js
+++ b/frontend/scripts/setup-live-reload.js
@@ -14,10 +14,33 @@ function setupLiveReload() {
   console.log("🔄 Syncing iOS project (cap sync ios)...");
   execSync("npx cap sync ios", { stdio: "inherit" });
 
+  // 부팅된 시뮬레이터의 UDID 가져오기
+  let targetOption = "";
+  try {
+    const bootedLine = execSync("xcrun simctl list devices | grep '(Booted)'", { 
+      encoding: "utf-8", 
+      stdio: "pipe" 
+    }).trim();
+    
+    if (bootedLine) {
+      // UDID 추출 (괄호 안의 첫 번째 값)
+      const udidMatch = bootedLine.match(/\(([A-F0-9-]+)\)/);
+      if (udidMatch && udidMatch[1]) {
+        const udid = udidMatch[1];
+        targetOption = ` --target ${udid}`;
+        console.log("📱 Using currently booted simulator automatically");
+      }
+    } else {
+      console.log("📱 No booted simulator found, Capacitor will show device selection");
+    }
+  } catch (error) {
+    console.log("📱 Capacitor will show device selection");
+  }
+
   // Live Reload로 iOS 앱 실행
   console.log("📱 Starting iOS app with Live Reload...");
   execSync(
-    `npx cap run ios --live-reload --host ${ip} --port ${port} --scheme ${scheme}`,
+    `npx cap run ios --live-reload --host ${ip} --port ${port} --scheme ${scheme}${targetOption}`,
     { stdio: "inherit" }
   );
 

--- a/worklogs/ios-deployment.md
+++ b/worklogs/ios-deployment.md
@@ -117,8 +117,63 @@ scripts/
 - CI/CD 파이프라인 통합 검토
 - 팀 개발을 위한 환경 설정 표준화
 
+---
+
+## [2025-08-24] iOS 시뮬레이터 자동 선택 기능 개선
+
+### 작업 개요
+- 사용자가 `yarn ios:dev` 실행 시 디바이스 선택 메뉴 없이 부팅된 시뮬레이터를 자동으로 사용하도록 개선
+- 개발 워크플로우의 추가적인 효율성 향상
+
+### 발생한 문제
+- **문제**: `yarn ios:dev` 실행 시 매번 시뮬레이터 선택 메뉴가 표시됨
+- **원인**: Capacitor의 기본 동작이 사용 가능한 디바이스 목록을 보여주고 사용자 선택을 요구
+- **사용자 요구사항**: 이미 부팅된 시뮬레이터가 있으면 자동으로 그것을 사용하고 싶음
+
+### 해결 방법
+부팅된 시뮬레이터의 UDID를 자동 감지하여 `--target` 옵션으로 전달하는 방식 구현:
+
+```javascript
+// 부팅된 시뮬레이터의 UDID 가져오기
+let targetOption = "";
+try {
+  const bootedLine = execSync("xcrun simctl list devices | grep '(Booted)'", { 
+    encoding: "utf-8", 
+    stdio: "pipe" 
+  }).trim();
+  
+  if (bootedLine) {
+    // UDID 추출 (괄호 안의 첫 번째 값)
+    const udidMatch = bootedLine.match(/\(([A-F0-9-]+)\)/);
+    if (udidMatch && udidMatch[1]) {
+      const udid = udidMatch[1];
+      targetOption = ` --target ${udid}`;
+      console.log("📱 Using currently booted simulator automatically");
+    }
+  } else {
+    console.log("📱 No booted simulator found, Capacitor will show device selection");
+  }
+} catch (error) {
+  console.log("📱 Capacitor will show device selection");
+}
+```
+
+### 구현 세부사항
+1. `xcrun simctl list devices | grep '(Booted)'`로 부팅된 시뮬레이터 확인
+2. 정규식을 사용하여 UDID 추출: `/\(([A-F0-9-]+)\)/`
+3. UDID가 있으면 `--target UDID` 옵션을 Capacitor 명령어에 추가
+4. UDID가 없으면 기본 동작(디바이스 선택 메뉴) 유지
+
+### 결과
+- 부팅된 시뮬레이터가 있는 경우: 자동으로 해당 시뮬레이터에서 앱 실행
+- 부팅된 시뮬레이터가 없는 경우: 기존처럼 디바이스 선택 메뉴 표시
+- 사용자 경험 추가 개선으로 개발 효율성 향상
+
+---
+
 ## 참고 문서
 - [Capacitor Live Reload 가이드](https://capacitorjs.com/docs/guides/live-reload)
 - [Capacitor Configuration](https://capacitorjs.com/docs/config)
 - [iOS Developer Program](https://developer.apple.com/programs/)
 - [Xcode 프로비저닝 가이드](https://developer.apple.com/documentation/xcode/distributing-your-app-for-beta-testing-and-releases)
+- [xcrun simctl 명령어 가이드](https://developer.apple.com/documentation/xcode/running-your-app-in-simulator-or-on-a-device)


### PR DESCRIPTION
## 작업 개요
- `yarn ios:dev` 실행 시 부팅된 iOS 시뮬레이터를 자동으로 감지하여 사용
- 개발자가 매번 디바이스를 선택하는 번거로움 제거
- 개발 워크플로우의 효율성 향상

## 주요 변경사항
- **자동 시뮬레이터 감지**: `xcrun simctl list devices | grep '(Booted)'`로 부팅된 시뮬레이터 확인
- **UDID 추출**: 정규식을 사용하여 시뮬레이터 UDID 자동 추출
- **타겟 옵션 적용**: `--target UDID` 옵션을 Capacitor 명령어에 자동 추가
- **fallback 처리**: 부팅된 시뮬레이터가 없으면 기존 디바이스 선택 메뉴 표시
- **워크로그 업데이트**: 구현 과정과 문제 해결 방법 문서화
- **가이드라인 추가**: 커밋 및 PR 작성 시 Claude Code 참조 문구 제거 정책

## 테스트 계획
- [x] 부팅된 시뮬레이터가 있을 때 자동 선택 동작 확인
- [x] 부팅된 시뮬레이터가 없을 때 디바이스 선택 메뉴 표시 확인
- [x] 여러 시뮬레이터가 부팅되어 있을 때 첫 번째 시뮬레이터 선택 확인
- [ ] 다양한 iOS 버전 시뮬레이터에서 동작 확인